### PR TITLE
Say on the page that scans are down right now

### DIFF
--- a/assets/home.css
+++ b/assets/home.css
@@ -739,3 +739,47 @@ kbd {
     min-width: 0;
   }
 }
+
+
+/* --------------------------------------------------------------------------
+   Outage notice: one band under the masthead while the scan is known broken
+
+   Temporary, and paired with the .outage-bar markup in index.html. Both come
+   out together once the fix ships. Warn amber rather than the page accent,
+   because the accent is what every working button on this page wears.
+   -------------------------------------------------------------------------- */
+
+.outage-bar {
+  border-block: 1px solid rgba(217, 164, 65, 0.28);
+  background: rgba(217, 164, 65, 0.1);
+}
+
+.outage-bar-inner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding-block: 14px;
+}
+
+/* Aligns with the first line of the sentence rather than the block, so the
+   triangle does not drift down as the text wraps to two or three lines. */
+.outage-bar-icon {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  color: var(--warn);
+}
+
+.outage-bar-text {
+  margin: 0;
+  max-width: var(--prose);
+  color: var(--ink);
+  font-size: var(--step--1);
+  line-height: 1.55;
+}
+
+.outage-bar-text strong {
+  color: var(--warn);
+  font-weight: 600;
+}

--- a/index.html
+++ b/index.html
@@ -147,6 +147,39 @@
     </header>
 
     <main id="main">
+      <!--
+        Outage notice. Instagram changed things on their end and a scan does
+        not come back with the right answer right now, so the band says so
+        before anyone copies the snippet. First thing inside main, so the skip
+        link lands on it rather than past it.
+
+        Temporary, and meant to be easy to take out: this block, and the
+        .outage-bar rules in home.css, come out together once the fix ships.
+        It is deliberately not dismissible and remembers nothing -- an outage
+        someone closed once is an outage they will not see again.
+      -->
+      <aside class="outage-bar">
+        <div class="shell outage-bar-inner">
+          <svg class="outage-bar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M10.3 3.9 1.9 18.4a2 2 0 0 0 1.7 3h16.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" />
+            <path d="M12 9v4.5" />
+            <path d="M12 17.2h.01" />
+          </svg>
+          <p class="outage-bar-text" lang="en">
+            <strong>Not working at the moment.</strong> Instagram changed
+            things on their end, so a scan does not come back with the right
+            answer right now. The cause is known and the fix is being worked
+            on; it should be live within a few days.
+          </p>
+          <p class="outage-bar-text" lang="tr">
+            <strong>Şu anda çalışmıyor.</strong> Instagram kendi tarafında bir
+            değişiklik yaptı, tarama şu an doğru sonuç vermiyor. Sorunun
+            kaynağı belli, düzeltme üzerinde çalışılıyor; birkaç gün içinde
+            yayında olacak.
+          </p>
+        </div>
+      </aside>
+
       <section class="hero">
         <div class="shell hero-split">
           <div>


### PR DESCRIPTION
Instagram changed things on their end and the home page still reads as if the snippet works — someone copies it, runs it, and finds out in the console. This puts a band under the masthead that says so before the copy button.

### What changed

- **`index.html`** — an `.outage-bar` block as the first child of `<main>`, so the skip link lands on it rather than past it. Both languages ship in the markup and CSS picks one, the same way every other translated string on this page works.
- **`assets/home.css`** — the `.outage-bar` rules, in `--warn` amber rather than the page accent, since the accent is what every *working* button on this page wears.

### Notes

- **Not dismissible, stores nothing**, unlike the promo bar above it. An outage someone closed once is an outage they will not see again.
- **Temporary by design.** The markup block and the CSS block each carry a comment saying they come out together once the fix ships. Two deletions, no leftovers.
- **Home page only.** `security.html`, `privacy.html` and `contact.html` are untouched — the snippet is copied from here. Happy to repeat it across all four if you would rather it be site-wide.
- **Wording is deliberately vague about the mechanism** ("Instagram changed things on their end") rather than naming an endpoint or a data format, so it stays true whatever the actual break turns out to be. The "within a few days" estimate is the one line worth a second look before this ships — drop it if you would rather not commit to a date.

### Checks

- `npm run check` — 27/27 tests pass, all three `node --check` targets clean.
- Rendered in headless Chromium at 1280×900 and 390×844, in both `en` and `tr`: the band shows, exactly one language is visible, and the text wraps to 3 and 5 lines respectively without pushing anything sideways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013giPERvjhZTHnYnvPjHndu

---
_Generated by [Claude Code](https://claude.ai/code/session_013giPERvjhZTHnYnvPjHndu)_